### PR TITLE
- Removed the test and set true

### DIFF
--- a/scripts/ci-proof.sh
+++ b/scripts/ci-proof.sh
@@ -14,4 +14,4 @@ SPARKDIR=/opt/gnat/libexec/spark/bin
 (test -x ${SPARKDIR}/cvc4 && echo `${SPARKDIR}/cvc4 --version`) || true
 (test -x ${SPARKDIR}/z3 && echo `${SPARKDIR}/z3 -version`) || true
 
-(which gnatprove && gnatprove -P security.gpr) || true
+gnatprove -P security.gpr


### PR DESCRIPTION
This script is now supposed to be called only on environments with the SPARK tools installed, so protecting the call to gnatprove and always returning success is counterproductive.